### PR TITLE
improve tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,5 @@ jobs:
           printenv | sort
       - name: Install rp-bp
         run: pip install . --verbose
-      - name: Get test data and set paths
-        run: |
-          wget https://data.dieterichlab.org/s/kYn5sY7YrJPWDiG/download -O data.zip
-          unzip data.zip
-          cd c-elegans-chrI-example
-          sed -i 's|/path/to/your/c-elegans-example|'`pwd`'|' c-elegans-test.yaml
       - name: Run tests
-        run: |
-          cd c-elegans-chrI-example
-          prepare-rpbp-genome c-elegans-test.yaml
-          run-all-rpbp-instances c-elegans-test.yaml --overwrite --num-cpus 2 --logging-level INFO --merge-replicates --run-replicates --keep-intermediate-files
+        run: python -m pytest . -s -v

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,4 @@ dependencies:
     - git+https://github.com/dieterich-lab/pybio-utils.git@1.0.0#egg=pbio
     - pysam==0.15.2 # with Samtools-1.7
     - pyyaml==5.4
+    - pytest

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -12,42 +12,6 @@ REF_LOC = 'c-elegans-chrI-example'
 REF_CONFIG = 'c-elegans-test.yaml'
 
 
-#@pytest.fixture(scope="module")
-def hash_file(filename):
-    
-    import hashlib
-    
-    hasher = hashlib.md5()
-    blockSize = 16 * 1024 * 1024
-    
-    with open(filename, 'r') as f:
-        while True:
-            fileBuffer = f.read(blockSize)
-            if not fileBuffer:
-                break
-            hasher.update(fileBuffer.encode('utf-8'))
-
-    return hasher.hexdigest()
-
-#@pytest.fixture(scope="module")
-def hash_gfile(filename):
-    
-    import hashlib
-    import gzip
-    
-    hasher = hashlib.md5()
-    blockSize = 16 * 1024 * 1024
-
-    with gzip.open(filename, 'rb') as f:
-        while True:
-            fileBuffer = f.read(blockSize)
-            if not fileBuffer:
-                break
-            hasher.update(fileBuffer)
-
-    return hasher.hexdigest()
-
-
 @pytest.fixture(scope="session")
 def data_loc(tmp_path_factory):
     
@@ -103,7 +67,7 @@ def get_genome(get_config):
 
 @pytest.fixture(scope="session")
 def get_files(get_genome):
-    
+
     import yaml
     import pbio.ribo.ribo_filenames as filenames
     
@@ -148,18 +112,8 @@ def get_files(get_genome):
                                        ref_config['genome_name'],
                                        is_annotated=True)
     }
-    
-    file_checkers = {
-        'transcript': hash_gfile,
-        'fasta': hash_file,
-        'orfs': hash_gfile,
-        'exons': hash_gfile,
-        'labels': hash_gfile
-    }
-    
-    
-    ret = []
-    for key, checker_function in file_checkers.items():
-        ret.append((files[key], ref_files[key], checker_function))
 
+    ret = []
+    for key in files:
+        ret.append((files[key], ref_files[key]))
     return ret

--- a/tests/regression/test_prepare_genome.py
+++ b/tests/regression/test_prepare_genome.py
@@ -1,18 +1,25 @@
 
 import pytest
+import gzip
 
 
-def check_hash(h1, h2, hash_func):
-    return hash_func(h1) == hash_func(h2)
-    
-#@pytest.mark.parametrize('files, ref_files, checker_function', 
-                         #[(files, ref_files, checker_function) for files, ref_files, checker_function in get_files])
-#def test_output(files, ref_files, checker_function):
-    #assert check_hash(files, ref_files, checker_function)
-    
+def get_lines(filename):
+    if filename.endswith(".gz"):
+        with gzip.open(filename, 'rb') as f:
+            return f.readlines()
+    with open(filename, 'r') as f:
+        return f.readlines()
+
+
+def files_match(file, ref_file):
+    try:
+        assert get_lines(file) == get_lines(ref_file)
+    except AssertionError as e:
+        e.args += ("File:", file, "Reference file:", ref_file)
+        raise
+    return True
+
+
 def test_output(get_files):
-    for files, ref_files, checker_function in get_files:
-        assert check_hash(files, ref_files, checker_function)
-        
-        
-        
+    for file, ref_file in get_files:
+        assert files_match(file, ref_file)


### PR DESCRIPTION
- assert equality of `readlines()` instead of hash
  - pytest then gives the diff & location if files differ
- add filenames to the args of the raised `AssertionError`
  - they are then also displayed by pytest when the test fails
- add to CI