### PR TITLE
add code coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,11 @@ jobs:
       - name: Install rp-bp
         run: pip install . --verbose
       - name: Run tests
-        run: python -m pytest . -s -v
+        run: python -m pytest . --cov=rpbp --cov-report=xml -s -v
+      - name: Upload code coverage to codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./coverage.xml
+          name: ${{ matrix.os }}
+          fail_ci_if_error: true
+          verbose: true

--- a/environment.yml
+++ b/environment.yml
@@ -24,3 +24,4 @@ dependencies:
       - pysam==0.15.2 # with Samtools-1.7
       - pyyaml==5.4
       - pytest
+      - pytest-cov


### PR DESCRIPTION
- add `pytest-cov` to conda environment
- generate code coverage report when pytest runs in CI
- upload report to codecov.io

Next step: go to https://github.com/apps/codecov and enable codecov integration for this repository to see coverage reports on github PRs