### PR TITLE
fix channel order in environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
-          channels: bioconda,conda-forge,defaults
+          channels: conda-forge,bioconda,defaults
           channel-priority: strict
           auto-update-conda: true
           auto-activate-base: false

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python
   - biopython
   - bowtie2
-  - cmdstanpy
+  - cmdstanpy>=1.0.0
   - dash
   - dash-bio
   - dash-bootstrap-components

--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,8 @@
 name: rpbp
 channels:
-  - defaults
   - conda-forge
   - bioconda
+  - defaults
 dependencies:
   - python
   - biopython


### PR DESCRIPTION
- order *has* to be (where first has highest priority):
  - conda-forge
  - bioconda
  - defaults
- i.e.
  - if a package is on conda-forge we should use that one
  - otherwise see if bioconda has it
  - otherwise look in defaults
- this ordering appears to take precedence over whatever the user has defined in their condarc for the channel order